### PR TITLE
Browserify fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "name": "ducksboard",
     "email": "hackers@ducksboard.com"
   },
+  "main": "src/jquery.gridster.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/ducksboard/gridster.js.git"
@@ -54,6 +55,6 @@
     ]
   },
   "browserify-shim": {
-    "jquery": "global:$"
+    "jquery": "$"
   }
 }


### PR DESCRIPTION
Minor fixes to make browserify work with Gridster. Browserify looks at "main" in package.json to know where to start. Just assigning jquery to '$' makes this hit the relevant global or window.
